### PR TITLE
Add error checking to Base64 decode

### DIFF
--- a/include/std/base64.e
+++ b/include/std/base64.e
@@ -21,9 +21,25 @@ constant aleph = {
 	'0','1','2','3','4','5','6','7','8','9','+','/'
 }
 
---#
---# - see also ccha in which inverted decode table is built.
---#
+--# Base64 decode table (-1 is invalid character)
+constant ccha = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63, 52,
+    53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1,
+     0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
+    16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1,
+    26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
+    42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
+}
 --# Pad character is '=' (61)
 --#
 --# encoded output of encode is mo more that 76 characters each.
@@ -163,7 +179,7 @@ end function
 --
 public function decode(sequence in) 
 	integer len, oidx, case3, tmp, index
-	sequence result, ccha
+	sequence result
 
 	-- TODO: Surely this is not the most efficient way of doing this
 	in = search:match_replace("\r\n", in, "")
@@ -187,14 +203,6 @@ public function decode(sequence in)
 	then
 		return -1
 	end if
-
-	--#
-	--# invert aleph to a decode table
-	--#
-	ccha = repeat(-1, 256)
-	for i = 1 to 64 do
-		ccha[aleph[i]] = i - 1
-	end for	
 
 	result = repeat('?', oidx)
 	for i = oidx to 1 by -1 do

--- a/include/std/base64.e
+++ b/include/std/base64.e
@@ -12,7 +12,6 @@ namespace base64
 
 include std/sequence.e
 include std/search.e
-include std/types.e
 
 constant aleph = {
 	'A','B','C','D','E','F','G','H','I','J','K','L','M',

--- a/include/std/base64.e
+++ b/include/std/base64.e
@@ -170,9 +170,9 @@ end function
 --	 # ##in## ~-- must be a simple sequence of length ##4## to ##76## .
 --
 -- Returns:
--- A **sequence**, base256 decode of passed sequence.
--- the length of data to decode must be a multiple of ##4## if ##in##
--- is valid, -1 otherwise
+-- A **sequence**, base256 decode of passed sequence if the length of
+-- the data to decode is a multiple of ##4## and a valid Base64 code.
+-- Otherwise, -1 is returned.
 --
 -- Comments:
 -- The calling program is expected to strip newlines and so on before calling.

--- a/tests/t_base64.e
+++ b/tests/t_base64.e
@@ -3,22 +3,88 @@ include std/unittest.e
 include std/base64.e
 
 sequence result, this
+object bad_result
 
 result = encode("a")
+test_equal("1 char encode", result, "YQ==")
 result = decode(result)
-test_equal("1 char conversion", result, "a")
+test_equal("1 char decode", result, "a")
 
 result = encode("12")
+test_equal("2 char encode", result, "MTI=")
 result = decode(result)
-test_equal("2 char conversion", result, "12")
+test_equal("2 char decode", result, "12")
 
 result = encode("XYZ")
+test_equal("3 char encode", result, "WFla")
 result = decode(result)
-test_equal("3 char conversion", result, "XYZ")
+test_equal("3 char decode", result, "XYZ")
+
+constant encode_table = {
+    "AQ==", --# 1
+    "AgI=", --# 2
+    "AwMD", --# 3
+    "BAQEBA==", --# 4
+    "BQUFBQU=", --# 5
+    "BgYGBgYG", --# 6
+    "BwcHBwcHBw==", --# 7
+    "CAgICAgICAg=", --# 8
+    "CQkJCQkJCQkJ", --# 9
+    "CgoKCgoKCgoKCg==", --# 10
+    "CwsLCwsLCwsLCws=", --# 11
+    "DAwMDAwMDAwMDAwM", --# 12
+    "DQ0NDQ0NDQ0NDQ0NDQ==", --# 13
+    "Dg4ODg4ODg4ODg4ODg4=", --# 14
+    "Dw8PDw8PDw8PDw8PDw8P", --# 15
+    "EBAQEBAQEBAQEBAQEBAQEA==", --# 16
+    "ERERERERERERERERERERERE=", --# 17
+    "EhISEhISEhISEhISEhISEhIS", --# 18
+    "ExMTExMTExMTExMTExMTExMTEw==", --# 19
+    "FBQUFBQUFBQUFBQUFBQUFBQUFBQ=", --# 20
+    "FRUVFRUVFRUVFRUVFRUVFRUVFRUV", --# 21
+    "FhYWFhYWFhYWFhYWFhYWFhYWFhYWFg==", --# 22
+    "FxcXFxcXFxcXFxcXFxcXFxcXFxcXFxc=", --# 23
+    "GBgYGBgYGBgYGBgYGBgYGBgYGBgYGBgY", --# 24
+    "GRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGQ==", --# 25
+    "GhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGho=", --# 26
+    "GxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsbGxsb", --# 27
+    "HBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHA==", --# 28
+    "HR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0=", --# 29
+    "Hh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4e", --# 30
+    "Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHw==", --# 31
+    "ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICA=", --# 32
+    "ISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEh", --# 33
+    "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIg==", --# 34
+    "IyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyM=", --# 35
+    "JCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk", --# 36
+    "JSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJQ==", --# 37
+    "JiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiY=", --# 38
+    "JycnJycnJycnJycnJycnJycnJycnJycnJycnJycnJycnJycnJycn", --# 39
+    "KCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKA==", --# 40
+    "KSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSk=", --# 41
+    "KioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioq", --# 42
+    "KysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKysrKw==", --# 43
+    "LCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCw=", --# 44
+    "LS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0t", --# 45
+    "Li4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLi4uLg==", --# 46
+    "Ly8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8=", --# 47
+    "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAw", --# 48
+    "MTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMQ==", --# 49
+    "MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjI=", --# 50
+    "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMz", --# 51
+    "NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NA==", --# 52
+    "NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU1NTU=", --# 53
+    "NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2NjY2", --# 54
+    "Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nzc3Nw==", --# 55
+    "ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg4ODg=", --# 56
+    "OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5OTk5"  --# 57
+}
 
 for i = 1 to 57 do
     this = repeat(i,i)
-    result = decode(encode(this))
+    result = encode(this)
+    test_equal(sprintf("%d byte encode", { i }), result, encode_table[i])
+    result = decode(result)
     test_equal(sprintf("%d byte conversion", { i }), result, this)
 end for
     
@@ -43,6 +109,15 @@ encoded =
 
 test_equal("Thomas Hobbes' Leviathan encode", encoded, encode(msg, 76))
 test_equal("Thomas Hobbes' Leviathan decode", msg, decode(encoded))
+
+bad_result = decode("aA=")
+test_equal("Length not a multiple of 4", bad_result, -1)
+
+bad_result = decode("a===")
+test_equal("Too many pad characters", bad_result, -1)
+
+bad_result = decode("YX!q")
+test_equal("Invalid base64 character", bad_result, -1)
 
 test_report()
 


### PR DESCRIPTION
Also in this PR, added pre-computed decode table based on this code so that the decode table does not need to be calculated every time `decode` is called:

```euphoria
constant aleph = {
	'A','B','C','D','E','F','G','H','I','J','K','L','M',
	'N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
	'a','b','c','d','e','f','g','h','i','j','k','l','m',
	'n','o','p','q','r','s','t','u','v','w','x','y','z',
	'0','1','2','3','4','5','6','7','8','9','+','/'
}

sequence ccha = repeat(-1, 256)
for i = 1 to 64 do
    ccha[aleph[i]] = i - 1
end for

? ccha
```

Also, made sure that encode and decode is tested independently instead of making sure that the decode of the encode returns the original value (you could actually get that to pass if encode and decode did nothing but return the input value 😃 )